### PR TITLE
add a ruby resident

### DIFF
--- a/examples/ruby-resident/simplest-commitbee/flux-kustomization.yaml
+++ b/examples/ruby-resident/simplest-commitbee/flux-kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: simplest-commitbee
+  namespace: simplest-commitbee
+spec:
+  interval: 1m0s
+  targetNamespace: simplest-commitbee
+  path: ./deploy/bases/flux-helm
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: simplest-commitbee
+  patches:
+    - patch: |-
+        $patch: delete
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: not-used
+      target:
+        kind: Namespace
+        name: simplest-commitbee

--- a/examples/ruby-resident/simplest-commitbee/gitrepository.yaml
+++ b/examples/ruby-resident/simplest-commitbee/gitrepository.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: simplest-commitbee
+  namespace: simplest-commitbee
+spec:
+  interval: 1m0s
+  ref:
+    branch: master
+  url: https://github.com/kingdonb/simplest-commitbee

--- a/examples/ruby-resident/simplest-commitbee/kustomization.yaml
+++ b/examples/ruby-resident/simplest-commitbee/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- flux-kustomization.yaml
+- gitrepository.yaml
+- namespace.yaml

--- a/examples/ruby-resident/simplest-commitbee/namespace.yaml
+++ b/examples/ruby-resident/simplest-commitbee/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: simplest-commitbee


### PR DESCRIPTION
We can tear it down from where it was already running, so this is a net-zero deployment with respect to memory

(The memory usage when the business end is functioning properly, looks like:

<img width="1433" alt="Screenshot 2023-02-21 at 7 35 09 PM" src="https://user-images.githubusercontent.com/3286998/220490493-d5bd78ae-7a0a-4952-b7a7-239d8debe481.png">

There's a resident part which is doing practically nothing but waiting, and there's a spike every hour when the process kicks into gear and does its thing...)

From: (internal grafana instance)

http://kube-prometheus-stack-grafana/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?orgId=1&refresh=10s&var-datasource=default&var-cluster=&var-namespace=vcluster-hephy-stg-turkey-local&var-pod=simplest-commitbee-cron-7bdf5d48c4-svlbs-x-simplest--8e6933c240&from=now-6h&to=now

This is an app that gets deployed by Helm chart. (We're going to set it up for automated upgrades in a couple of different environments, some of them won't exercise the business end. There is a web process and a health check for that, but it is not used anywhere and it does not serve any purpose except for vestigial, Hephy Workflow/Deis Workflow used to require it.)